### PR TITLE
updated to base box 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,24 @@ The repository also contains a number of example notebooks.
 
 The contents of the VM are:
 
-* Apache Spark 1.6.1
+* Apache Spark 1.6.2
 * Python 2.7.8 from the Software Collections
-* A virtualenv for Python 2.7.8 with a scientific Python stack (scipy, numpy,
-* matplotplib, pandas, statmodels, scikit-learn, gensim, networkx, theano+keras, mpld3, seaborn) plus IPython 4 + Jupyter notebook
-* R 3.3.0 with a few packages installed (rmarkdown, magrittr, dplyr, tidyr, data.table, ggplot2, caret plus their dependencies)
+* A virtualenv for Python 2.7.8 with a scientific Python stack (scipy, numpy, matplotplib, pandas, statmodels, scikit-learn, gensim, networkx, theano+keras, mpld3, seaborn) plus IPython 4 + Jupyter notebook
+* R 3.3.1 with a few packages installed (rmarkdown, magrittr, dplyr, tidyr, data.table, ggplot2, caret plus their dependencies)
 * Spark notebook Kernels for Python 2.7, Scala ([Toree](https://toree.incubator.apache.org/)) and R ([IRKernel](https://github.com/IRkernel/IRkernel)), in addition to the default "plain" (i.e. non-Spark capable) Python 2.7 kernel.
 * A few small [notebook extensions](https://github.com/paulovn/nbextensions)
 * A notebook startup daemon script with facilities to configure Spark execution mode
-* Three additional Spark external libraries:
+* Two additional Spark external libraries (plus configuration prepared to use the [GraphFrames](http://graphframes.github.io/) package)
   - The Kafka Spark Streaming artifact
   - The [Spark CSV](https://github.com/databricks/spark-csv) library
-  - The [GraphFrames](http://graphframes.github.io/) Spark package.
 
-**Important**: in this installation the default Python kernel for notebooks 
-is **not** Spark-aware. Hence Python Notebooks running Spark tasks that were 
-created with previous versions of this VM will not work initially. 
+**Important**: the default Python kernel for notebooks is **not** Spark-aware. 
+To develop notebooks in Python for Spark, the `Pyspark (Py 2)` kernel must be 
+specifically selected. Hence Spark Python Notebooks that were created elsewhere
+(or with former versions of this VM) will not work initially. 
 They can be made to work by changing its kernel (use the option in the menubar)
 to the "Pyspark" kernel. Once done, it is stored in the notebook, so saving
-it will make it work in future executions (but the saved notebook will *not*
-work in a previous version of the VM).
+it will make it work in future executions.
 
 
 ## Installation
@@ -175,7 +173,7 @@ the `./vmfiles/hive` directory in the host (mounted in the VM).
 Note that due to Derby being a single-process DB, only one Spark SQL process 
 may be active at any given moment (since it would collide over the use of the 
 metastore). This means that there should be only one active Notebook (or Spark 
-shell) making use of an sqlContext.
+shell) making use of an `sqlContext`.
  
 
 ### Security

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,7 +97,7 @@ Vagrant.configure(2) do |config|
     #config.name = "vgr-pyspark"
 
     # The base box we are using. As fetched from ATLAS
-    vgrspark.vm.box_version = "= 0.9.12"
+    vgrspark.vm.box_version = "= 1.0.0"
     vgrspark.vm.box = "paulovn/spark-base64"
 
     # Alternative place: UAM internal
@@ -151,7 +151,7 @@ Vagrant.configure(2) do |config|
 
     # RStudio server
     # =====> uncomment if using RStudio
-    # vgrspark.vm.network :forwarded_port, host: 8787, guest: 8787
+    #vgrspark.vm.network :forwarded_port, host: 8787, guest: 8787
 
     # In case we want to fix Spark ports
     #vgrspark.vm.network :forwarded_port, host: 9234, guest: 9234
@@ -386,9 +386,9 @@ EOF
       inline: <<-SHELL
         echo "Downloading & installing RStudio Server"
         # Download & install the RPM for RStudio server
-        PKG=rstudio-server-rhel-0.99.902-x86_64.rpm
+        PKG=rstudio-server-rhel-0.99.903-x86_64.rpm
         wget --no-verbose https://download2.rstudio.org/$PKG
-        sudo yum install -y --nogpgcheck $PKG
+        yum install -y --nogpgcheck $PKG
         rm $PKG
         # Define the directory for the user library
         echo "r-libs-user=~/.Rlibrary" >> /etc/rstudio/rsession.conf
@@ -409,18 +409,20 @@ EOF
     if (provision_run_nbc)
       vgrspark.vm.provision "21.nbc",
       type: "shell",
-      privileged: false,
+      privileged: true,
       keep_color: true,
+      args: [ vm_username ],
       inline: <<-SHELL
           echo "Installing nbconvert requisites"
-          sudo yum install -y pandoc inkscape
-          pip install pandoc
+          yum install -y pandoc inkscape
+          sudo -i -u vagrant pip install pandoc
           DIR=$(kpsewhich -var-value TEXMFLOCAL)
           mkdir -p $DIR
           cd $DIR
           for p in collectbox adjustbox; do
             wget --no-verbose http://mirrors.ctan.org/install/macros/latex/contrib/$p.tds.zip
-            unzip $p.tds.zip
+            unzip -o $p.tds.zip
+            rm $p.tds.zip
           done
           texhash
       SHELL
@@ -441,8 +443,8 @@ EOF
         yum -y install python27-tkinter
         su -l "vagrant" <<-EOF
          pip install nltk graphviz
-         pip install https://github.com/paulovn/sparql-kernel/archive/master.zip
-         pip install https://github.com/paulovn/aiml-chatbot-kernel/archive/master.zip
+         pip install aimlbotkernel
+         pip install sparqlkernel
 EOF
         su -l "$1" <<-EOF
          echo "Installing AIML-BOT & SPARQL kernels"


### PR DESCRIPTION
* _Vagrantfile_ uses base box 1.0.0 (which includes Spark 1.6.2)
* fixed provisioning for `21.nbc` & `22.ai`
* updated Rstudio version for provisioning `20.rstudio`